### PR TITLE
refactor: use log instead of fmt

### DIFF
--- a/discoverer/fetcher/tar1090fetcher.go
+++ b/discoverer/fetcher/tar1090fetcher.go
@@ -3,8 +3,8 @@ package fetcher
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
+	"log"
 	"net/http"
 
 	"github.com/corinm/aircraft/discovery/data"
@@ -79,7 +79,7 @@ func (f Tar1090AdsbFetcher) FetchAircraft() ([]data.Aircraft, error) {
 	}
 	defer resp.Body.Close()
 
-	fmt.Println("HTTP GET request to tar1090 API completed with status:", resp.Status)
+	log.Println("HTTP GET request to tar1090 API completed with status:", resp.Status)
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.New("failed to fetch tar1090 data, resp.Status: " + resp.Status)
@@ -102,7 +102,7 @@ func (f Tar1090AdsbFetcher) FetchAircraft() ([]data.Aircraft, error) {
 		aircraft = append(aircraft, transformTar1090AircraftToAircraft(a))
 	}
 
-	fmt.Println("Processed", len(d.Aircraft), "aircraft from tar1090 response")
+	log.Println("Processed", len(d.Aircraft), "aircraft from tar1090 response")
 
 	return aircraft, nil
 }

--- a/discoverer/main.go
+++ b/discoverer/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
 
@@ -10,15 +9,17 @@ import (
 )
 
 func main() {
-	fmt.Println("Discoverer starting...")
+	log.Println("Discoverer starting...")
 
 	err := godotenv.Load()
 	if err != nil {
 		log.Fatal("Error loading .env file")
+		panic("Error loading .env file")
 	}
 
 	tar1090Url := os.Getenv("TAR1090_URL")
 	if tar1090Url == "" {
+		log.Fatal("TAR1090_URL environment variable is not set")
 		panic("TAR1090_URL not set")
 	}
 
@@ -28,13 +29,13 @@ func main() {
 
 	// TODO: Do this next bit in a loop
 
-	fmt.Println("Fetching aircraft data...")
+	log.Println("Fetching aircraft data...")
 
 	_, err2 := f.FetchAircraft()
 	if err2 != nil {
-		fmt.Println("Error fetching aircraft:", err2)
+		log.Println("Error fetching aircraft:", err2)
 		return
 	}
 
-	fmt.Println("Discoverer finished")
+	log.Println("Discoverer finished")
 }


### PR DESCRIPTION
## Description

- Up until now I've been using `fmt.Println` for logging
- This PR switches to using `log.Println` / `log.Fatal`, which is better designed for logging and includes features like timestamps
