### PR TITLE
refactor: improve enricher

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ go run main.go
 - [x] Re-add NATS
 - [ ] Implement `enricher` service
   - [x] Enrich with HexDB data
+  - [ ] Use Context appropriately with enrichers (e.g. set deadline, cancel gracefully)
   - [ ] Enrich with PlaneAlertDb data (i.e. whether it's an interesting aircraft and why)
   - [ ] Investigate any other potential data sources
 - [ ] Implement `evaluator` service

--- a/enricher/main.go
+++ b/enricher/main.go
@@ -44,8 +44,7 @@ func main() {
 		// Process message, enrich aircraft, republish to enriched subject
 		aircraft := &data.EnrichedAircraft{AiocHexCode: string(msg.Data)}
 
-		err := pipeline.EnrichAircraft(aircraft, enrichers)
-		if err != nil {
+		if err := pipeline.EnrichAircraft(aircraft, enrichers); err != nil {
 			log.Println("Error enriching aircraft:", err)
 			return
 		}

--- a/enricher/main.go
+++ b/enricher/main.go
@@ -18,30 +18,13 @@ import (
 func main() {
 	log.Println("Enricher starting...")
 
-	if err := godotenv.Load(); err != nil {
-		log.Fatal("Failed to load .env file")
-		panic("Error loading .env file")
+	config, err := loadConfig()
+	if err != nil {
+		log.Fatal("Error loading configuration:", err)
+		panic(err)
 	}
 
-	natsHost := os.Getenv("DISCOVERY_NATS_HOST")
-	if natsHost == "" {
-		log.Fatal("DISCOVERY_NATS_HOST environment variable is not set")
-		panic("DISCOVERY_NATS_HOST not set")
-	}
-	
-	natsPort := os.Getenv("DISCOVERY_NATS_PORT")
-	if natsPort == "" {
-		log.Fatal("DISCOVERY_NATS_PORT environment variable is not set")
-		panic("DISCOVERY_NATS_PORT not set")
-	}
-
-	natsUrl := natsHost + ":" + natsPort
-
-	hexDbUrl := os.Getenv("HEXDB_URL")
-	if hexDbUrl == "" {
-		log.Fatal("HEXDB_URL environment variable is not set")
-		panic("HEXDB_URL not set")
-	}
+	natsUrl := config.DiscoveryNatsHost + ":" + config.DiscoveryNatsPort
 
 	log.Printf("Connecting to NATS at %s...\n", natsUrl)
 	m, err := messaging.NewNatsMessaging(natsUrl)
@@ -53,7 +36,7 @@ func main() {
 	log.Println("Connected to NATS")
 	
 	enrichers := []pipeline.Enricher{
-		&pipeline.HexDbEnricher{HexDbUrl: hexDbUrl},
+		&pipeline.HexDbEnricher{HexDbUrl: config.HexDbUrl},
 	}
 
 	m.Subscribe("aircraft.raw", func(msg *nats.Msg) {
@@ -89,4 +72,33 @@ func main() {
     <-sigChan // blocks until a signal is received
     fmt.Println("Shutting down gracefully...")
     m.Drain()
+}
+
+type Config struct {
+	DiscoveryNatsHost string `env:"DISCOVERY_NATS_HOST"`
+	DiscoveryNatsPort string `env:"DISCOVERY_NATS_PORT"`
+	HexDbUrl          string `env:"HEXDB_URL"`
+}
+
+func loadConfig() (Config, error) {
+	if err := godotenv.Load(); err != nil {
+		return Config{}, fmt.Errorf("failed to load .env file: %w", err)
+	}
+
+	var config Config
+
+	config.DiscoveryNatsHost = os.Getenv("DISCOVERY_NATS_HOST")
+	if config.DiscoveryNatsHost == "" {
+		return Config{}, fmt.Errorf("DISCOVERY_NATS_HOST environment variable is not set")
+	}
+	config.DiscoveryNatsPort = os.Getenv("DISCOVERY_NATS_PORT")
+	if config.DiscoveryNatsPort == "" {
+		return Config{}, fmt.Errorf("DISCOVERY_NATS_PORT environment variable is not set")
+	}
+	config.HexDbUrl = os.Getenv("HEXDB_URL")
+	if config.HexDbUrl == "" {
+		return Config{}, fmt.Errorf("HEXDB_URL environment variable is not set")
+	}
+	
+	return config, nil
 }

--- a/enricher/pipeline/pipeline.go
+++ b/enricher/pipeline/pipeline.go
@@ -4,8 +4,12 @@ import (
 	"enricher/data"
 )
 
-func EnrichAircraft(a *data.EnrichedAircraft, enrichers []Enricher) error {
-	for _, enricher := range enrichers {
+type Pipeline struct {
+	Enrichers []Enricher
+}
+
+func (p *Pipeline) Enrich(a *data.EnrichedAircraft) error {
+	for _, enricher := range p.Enrichers {
 		if err := enricher.Enrich(a); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

A few refactoring changes:

- Abstract out loading of config to declutter the `main` function
- Change pipeline so that it is instantiated up-front and then called with each aircraft. I think this creates a simpler interface for the consumer of the pipeline.
- Add a timeout to the HexDB HTTP request
- Use a `json.Decoder` to avoid use of `io.ReadAll` and need for separate unmarshalling of JSON