### PR TITLE
fix: correct icao spelling

### DIFF
--- a/discoverer/data/aircraft.go
+++ b/discoverer/data/aircraft.go
@@ -1,5 +1,5 @@
 package data
 
 type RawAircraft struct {
-	AiocHexCode      string // e.g. "4CA293"
+	IcaoHexCode      string // e.g. "4CA293"
 }

--- a/discoverer/fetcher/tar1090fetcher.go
+++ b/discoverer/fetcher/tar1090fetcher.go
@@ -103,5 +103,5 @@ func (f Tar1090AdsbFetcher) FetchAircraft() ([]data.RawAircraft, error) {
 }
 
 func transformTar1090AircraftToAircraft(a tar1090response_aircraft) data.RawAircraft {
-	return data.RawAircraft{ AiocHexCode: a.Hex }
+	return data.RawAircraft{ IcaoHexCode: a.Hex }
 }

--- a/discoverer/main.go
+++ b/discoverer/main.go
@@ -83,7 +83,7 @@ func fetchAndPublishAircraft(f fetcher.Tar1090AdsbFetcher, m *messaging.NatsMess
 	log.Printf("Found %d aircraft\n", len(aircraft))
 
 	for _, a := range aircraft {
-		err := m.Publish("aircraft.raw", []byte(a.AiocHexCode))
+		err := m.Publish("aircraft.raw", []byte(a.IcaoHexCode))
 		if err != nil {
 			log.Println("Error publishing aircraft:", err)
 		}

--- a/enricher/data/aircraft.go
+++ b/enricher/data/aircraft.go
@@ -5,7 +5,7 @@ type EnrichedAircraft struct {
 
 	Registration         string   `json:"registration"`         // e.g. "G-EZBZ"
 	Manufacturer         string   `json:"manufacturer"`         // e.g. "Boeing"
-	ICAOTypeCode         string   `json:"icaoTypeCode"`         // e.g. "B738"
+	IcaoTypeCode         string   `json:"icaoTypeCode"`         // e.g. "B738"
 	AircraftType         string   `json:"aircraftType"`         // e.g. "Boeing 737-800"
 	RegisteredOwners     string   `json:"registeredOwners"`     // e.g. "easyJet UK"
 	IcaoAirlineCode      string   `json:"icaoAirlineCode"`      // e.g. "EZY"

--- a/enricher/data/aircraft.go
+++ b/enricher/data/aircraft.go
@@ -1,7 +1,7 @@
 package data
 
 type EnrichedAircraft struct {
-	AiocHexCode          string   `json:"aiocHexCode"`          // e.g. "4CA293"
+	IcaoHexCode          string   `json:"icaoHexCode"`          // e.g. "4CA293"
 
 	Registration         string   `json:"registration"`         // e.g. "G-EZBZ"
 	Manufacturer         string   `json:"manufacturer"`         // e.g. "Boeing"

--- a/enricher/main.go
+++ b/enricher/main.go
@@ -57,7 +57,7 @@ func main() {
 
 			log.Println("Handling aircraft with hex code:", string(msg.Data))
 
-			aircraft := &data.EnrichedAircraft{AiocHexCode: string(msg.Data)}
+			aircraft := &data.EnrichedAircraft{IcaoHexCode: string(msg.Data)}
 
 			if err := p.Enrich(ctx, aircraft); err != nil {
 				log.Println("Error enriching aircraft:", err)
@@ -75,7 +75,7 @@ func main() {
 				return
 			}
 
-			log.Println("Aircraft handled successfully:", aircraft.AiocHexCode)
+			log.Println("Aircraft handled successfully:", aircraft.IcaoHexCode)
 		}()
 	})
 

--- a/enricher/pipeline/hexdb.go
+++ b/enricher/pipeline/hexdb.go
@@ -51,7 +51,7 @@ func hexDbGetAircraftInformation(ctx context.Context, hex string) (*hexDbRespons
 }
 
 func (e *HexDbEnricher) Enrich(ctx context.Context, a *data.EnrichedAircraft) error {
-	resp, err := hexDbGetAircraftInformation(ctx, a.AiocHexCode)
+	resp, err := hexDbGetAircraftInformation(ctx, a.IcaoHexCode)
 	if err != nil {
 		return err
 	}

--- a/enricher/pipeline/hexdb.go
+++ b/enricher/pipeline/hexdb.go
@@ -17,7 +17,7 @@ type hexDbResponse struct {
 	// ModeS            string `json:"ModeS"`
 	Registration     string `json:"Registration"`
 	Manufacturer     string `json:"Manufacturer"`
-	ICAOTypeCode     string `json:"ICAOTypeCode"`
+	IcaoTypeCode     string `json:"ICAOTypeCode"`
 	Type             string `json:"Type"`
 	RegisteredOwners string `json:"RegisteredOwners"`
 	OperatorFlagCode string `json:"OperatorFlagCode"`
@@ -58,7 +58,7 @@ func (e *HexDbEnricher) Enrich(ctx context.Context, a *data.EnrichedAircraft) er
 
 	a.Registration = resp.Registration
 	a.Manufacturer = resp.Manufacturer
-	a.ICAOTypeCode = resp.ICAOTypeCode
+	a.IcaoTypeCode = resp.IcaoTypeCode
 	a.AircraftType = resp.Type
 	a.RegisteredOwners = resp.RegisteredOwners
 	a.IcaoAirlineCode = resp.OperatorFlagCode

--- a/evaluator/data/aircraft.go
+++ b/evaluator/data/aircraft.go
@@ -5,7 +5,7 @@ type EnrichedAircraft struct {
 
 	Registration         string   `json:"registration"`         // e.g. "G-EZBZ"
 	Manufacturer         string   `json:"manufacturer"`         // e.g. "Boeing"
-	ICAOTypeCode         string   `json:"icaoTypeCode"`         // e.g. "B738"
+	IcaoTypeCode         string   `json:"icaoTypeCode"`         // e.g. "B738"
 	AircraftType         string   `json:"aircraftType"`         // e.g. "Boeing 737-800"
 	RegisteredOwners     string   `json:"registeredOwners"`     // e.g. "easyJet UK"
 	IcaoAirlineCode      string   `json:"icaoAirlineCode"`      // e.g. "EZY"

--- a/evaluator/data/aircraft.go
+++ b/evaluator/data/aircraft.go
@@ -1,7 +1,7 @@
 package data
 
 type EnrichedAircraft struct {
-	AiocHexCode          string   `json:"aiocHexCode"`          // e.g. "4CA293"
+	IcaoHexCode          string   `json:"icaoHexCode"`          // e.g. "4CA293"
 
 	Registration         string   `json:"registration"`         // e.g. "G-EZBZ"
 	Manufacturer         string   `json:"manufacturer"`         // e.g. "Boeing"

--- a/evaluator/main.go
+++ b/evaluator/main.go
@@ -55,7 +55,7 @@ func main() {
 			return
 		}
 
-		log.Printf("Evaluating aircraft: %s\n", aircraft.AiocHexCode)
+		log.Printf("Evaluating aircraft: %s\n", aircraft.IcaoHexCode)
 		shouldNotify, err := evaluateAircraft(aircraft)
 		if err != nil {
 			log.Println("Error evaluating aircraft:", err)
@@ -63,11 +63,11 @@ func main() {
 		}
 
 		if !shouldNotify {
-			log.Printf("Aircraft %s does not meet criteria, no notification sent.\n", aircraft.AiocHexCode)
+			log.Printf("Aircraft %s does not meet criteria, no notification sent.\n", aircraft.IcaoHexCode)
 			return
 		}
 
-		log.Printf("Aircraft %s meets criteria, sending notification...\n", aircraft.AiocHexCode)
+		log.Printf("Aircraft %s meets criteria, sending notification...\n", aircraft.IcaoHexCode)
 		// Print the response if you want
 		if err := m.Publish("aircraft.interesting", msg.Data); err != nil {
 			log.Println("Error republishing enriched aircraft:", err)

--- a/notifier/data/aircraft.go
+++ b/notifier/data/aircraft.go
@@ -5,7 +5,7 @@ type EnrichedAircraft struct {
 
 	Registration         string   `json:"registration"`         // e.g. "G-EZBZ"
 	Manufacturer         string   `json:"manufacturer"`         // e.g. "Boeing"
-	ICAOTypeCode         string   `json:"icaoTypeCode"`         // e.g. "B738"
+	IcaoTypeCode         string   `json:"icaoTypeCode"`         // e.g. "B738"
 	AircraftType         string   `json:"aircraftType"`         // e.g. "Boeing 737-800"
 	RegisteredOwners     string   `json:"registeredOwners"`     // e.g. "easyJet UK"
 	IcaoAirlineCode      string   `json:"icaoAirlineCode"`      // e.g. "EZY"

--- a/notifier/data/aircraft.go
+++ b/notifier/data/aircraft.go
@@ -1,7 +1,7 @@
 package data
 
 type EnrichedAircraft struct {
-	AiocHexCode          string   `json:"aiocHexCode"`          // e.g. "4CA293"
+	IcaoHexCode          string   `json:"IcaoHexCode"`          // e.g. "4CA293"
 
 	Registration         string   `json:"registration"`         // e.g. "G-EZBZ"
 	Manufacturer         string   `json:"manufacturer"`         // e.g. "Boeing"

--- a/notifier/main.go
+++ b/notifier/main.go
@@ -91,5 +91,5 @@ func main() {
 }
 
 func formatAircraft(aircraft data.EnrichedAircraft) string {
-	return fmt.Sprintf("Interesting aircraft: %s (%s) %s %s %s", aircraft.Registration, aircraft.AiocHexCode, aircraft.RegisteredOwners, aircraft.Manufacturer, aircraft.AircraftType)
+	return fmt.Sprintf("Interesting aircraft: %s (%s) %s %s %s", aircraft.Registration, aircraft.IcaoHexCode, aircraft.RegisteredOwners, aircraft.Manufacturer, aircraft.AircraftType)
 }


### PR DESCRIPTION
## Description

For better consistency:
- Fix mispelling of "Aioc" to "Icao"
- Change case of "ICAO to "Icao"
